### PR TITLE
Suppress assertion failure when using CComMultiThreadModel.

### DIFF
--- a/ProtocolImpl.h
+++ b/ProtocolImpl.h
@@ -342,7 +342,7 @@ public:
 	CComPtr<IInternetProtocol> m_spTargetProtocol;
 };
 
-template <class ThreadModel = CComSingleThreadModel>
+template <class ThreadModel = CComMultiThreadModel>
 class CInternetProtocolSinkTM :
 	public CComObjectRootEx<ThreadModel>,
 	public IInternetProtocolSinkImpl
@@ -370,7 +370,7 @@ public:
 
 typedef CInternetProtocolSinkTM<> CInternetProtocolSink;
 
-template <class T, class ThreadModel = CComSingleThreadModel>
+template <class T, class ThreadModel = CComMultiThreadModel>
 class CInternetProtocolSinkWithSP :
 	public CInternetProtocolSinkTM<ThreadModel>
 {
@@ -401,7 +401,7 @@ public:
 			GetUnknown(), riid, ppvObject, GetClientServiceProvider()); \
 	}
 
-template <class StartPolicy, class ThreadModel = CComSingleThreadModel>
+template <class StartPolicy, class ThreadModel = CComMultiThreadModel>
 class ATL_NO_VTABLE CInternetProtocol :
 	public CComObjectRootEx<ThreadModel>,
 	public IInternetProtocolImpl,

--- a/SinkPolicy.inl
+++ b/SinkPolicy.inl
@@ -132,7 +132,16 @@ inline HRESULT CComPolyObjectSharedRef<Contained>::FinalConstruct()
 	InternalAddRef();
 	CComObjectRootEx<Contained::_ThreadModel::ThreadModelNoCS>::
 		FinalConstruct();
-	HRESULT hr = m_contained.FinalConstruct();
+	HRESULT hr;
+#if _ATL_VER >= 0x800
+	hr = m_contained._AtlInitialConstruct();  // gears - added by andreip
+	if (SUCCEEDED(hr))
+#endif
+		hr = m_contained.FinalConstruct();
+#if _ATL_VER >= 0x800
+	if (SUCCEEDED(hr))
+		hr = m_contained._AtlFinalConstruct();  // gears - added by andreip
+#endif
 	InternalRelease();
 	return hr;
 }
@@ -299,7 +308,16 @@ inline HRESULT CComObjectProtSink<ProtocolObject, SinkObject>::
 	m_refCount.InternalAddRef();
 	m_refCount.FinalConstruct();
 	HRESULT hr = ProtocolObject::FinalConstruct();
-	HRESULT hrSink = m_sink.FinalConstruct();
+	HRESULT hrSink;
+#if _ATL_VER >= 0x800
+	hrSink = m_sink._AtlInitialConstruct();  // gears - added by zork
+	if (SUCCEEDED(hrSink))
+#endif
+		hrSink = m_sink.FinalConstruct();
+#if _ATL_VER >= 0x800
+	if (SUCCEEDED(hrSink))
+		hrSink = m_sink._AtlFinalConstruct();  // gears - added by zork
+#endif
 	if (SUCCEEDED(hr) && FAILED(hrSink))
 	{
 		hr = hrSink;

--- a/SinkPolicy.inl
+++ b/SinkPolicy.inl
@@ -134,13 +134,13 @@ inline HRESULT CComPolyObjectSharedRef<Contained>::FinalConstruct()
 		FinalConstruct();
 	HRESULT hr;
 #if _ATL_VER >= 0x800
-	hr = m_contained._AtlInitialConstruct();  // gears - added by andreip
+	hr = m_contained._AtlInitialConstruct();
 	if (SUCCEEDED(hr))
 #endif
 		hr = m_contained.FinalConstruct();
 #if _ATL_VER >= 0x800
 	if (SUCCEEDED(hr))
-		hr = m_contained._AtlFinalConstruct();  // gears - added by andreip
+		hr = m_contained._AtlFinalConstruct();
 #endif
 	InternalRelease();
 	return hr;
@@ -310,13 +310,13 @@ inline HRESULT CComObjectProtSink<ProtocolObject, SinkObject>::
 	HRESULT hr = ProtocolObject::FinalConstruct();
 	HRESULT hrSink;
 #if _ATL_VER >= 0x800
-	hrSink = m_sink._AtlInitialConstruct();  // gears - added by zork
+	hrSink = m_sink._AtlInitialConstruct();
 	if (SUCCEEDED(hrSink))
 #endif
 		hrSink = m_sink.FinalConstruct();
 #if _ATL_VER >= 0x800
 	if (SUCCEEDED(hrSink))
-		hrSink = m_sink._AtlFinalConstruct();  // gears - added by zork
+		hrSink = m_sink._AtlFinalConstruct();
 #endif
 	if (SUCCEEDED(hr) && FAILED(hrSink))
 	{


### PR DESCRIPTION
Using CComMultiThreadModel for the sink and protocol objects resolves a random crash problem in higher versions of IE(IE10 & 11). See http://social.msdn.microsoft.com/Forums/ie/en-US/f2a63a7e-dcd0-4d76-9824-94c8b81a3e9c/app-sdk-crash-in-iinternetprotocolimplunlockrequest?forum=ieextensiondevelopment for the detailed discussion.

Unfortunately, this version of PassthroughAPP generates a runtime assertion failure when using CComMultiThreadModel for the sink and protocol objects:

``` C++
In ATL::CComSafeDeleteCriticalSection::Lock()
    HRESULT Lock()
    {
        // CComSafeDeleteCriticalSection::Init or CComAutoDeleteCriticalSection::Init
        // not called or failed.
        // m_critsec member of CComObjectRootEx is now of type
        // CComAutoDeleteCriticalSection. It has to be initialized
        // by calling CComObjectRootEx::_AtlInitialConstruct
        ATLASSUME(m_bInitialized);
        return CComCriticalSection::Lock();
    }
```

The reason is that calling _AtlInitialConstruct is needed in ATL version 8 (or higher) but is not called in the FinalConstruct function of the protocol and sink objects. This patch adds these calls.
