### PR TITLE
Fix compilation with _ATL_NO_AUTOMATIC_NAMESPACE

### DIFF
--- a/ProtocolCF.h
+++ b/ProtocolCF.h
@@ -33,7 +33,7 @@ struct ChooseCreatorClass
 } // end namespace PassthroughAPP::Detail
 
 class ATL_NO_VTABLE CComClassFactoryProtocol :
-	public CComClassFactory
+	public ATL::CComClassFactory
 {
 	typedef CComClassFactory BaseClass;
 public:
@@ -48,16 +48,16 @@ public:
 
 	void FinalRelease();
 private:
-	CComPtr<IClassFactory> m_spTargetCF;
+	ATL::CComPtr<IClassFactory> m_spTargetCF;
 };
 
 template <class Factory, class Protocol,
-	class FactoryComObject = CComObjectNoLock<Factory> >
+	class FactoryComObject = ATL::CComObjectNoLock<Factory> >
 struct CMetaFactory
 {
 	typedef
-		CComCreator2<CComCreator<CComObject<Protocol> >,
-			CComCreator<CComAggObject<Protocol> > >
+		ATL::CComCreator2<ATL::CComCreator<ATL::CComObject<Protocol> >,
+			ATL::CComCreator<ATL::CComAggObject<Protocol> > >
 	DefaultCreatorClass;
 
 	typedef typename

--- a/ProtocolCF.inl
+++ b/ProtocolCF.inl
@@ -26,11 +26,11 @@ inline STDMETHODIMP CComClassFactoryProtocol::CreateInstance(
 	}
 	*ppvObj = 0;
 
-	CComPtr<IUnknown> spUnkTarget;
+	ATL::CComPtr<IUnknown> spUnkTarget;
 	HRESULT hr = CreateInstanceTarget(&spUnkTarget);
 	ATLASSERT(SUCCEEDED(hr) && spUnkTarget != 0);
 
-	CComPtr<IUnknown> spUnkObject;
+	ATL::CComPtr<IUnknown> spUnkObject;
 	if (SUCCEEDED(hr))
 	{
 		hr = BaseClass::CreateInstance(punkOuter, riid,
@@ -40,7 +40,7 @@ inline STDMETHODIMP CComClassFactoryProtocol::CreateInstance(
 
 	if (SUCCEEDED(hr))
 	{
-		CComPtr<IPassthroughObject> spPassthroughObj;
+		ATL::CComPtr<IPassthroughObject> spPassthroughObj;
 		hr = spUnkObject->QueryInterface(&spPassthroughObj);
 		ATLASSERT(SUCCEEDED(hr) && spPassthroughObj != 0);
 		if (SUCCEEDED(hr))
@@ -67,7 +67,7 @@ inline HRESULT CComClassFactoryProtocol::CreateInstanceTarget(
 	}
 	*ppTargetProtocol = 0;
 
-	CComPtr<IClassFactory> spTargetCF;
+	ATL::CComPtr<IClassFactory> spTargetCF;
 	HRESULT hr = GetTargetClassFactory(&spTargetCF);
 	ATLASSERT(SUCCEEDED(hr) && spTargetCF != 0);
 	if (SUCCEEDED(hr))
@@ -109,7 +109,7 @@ inline HRESULT CComClassFactoryProtocol::SetTargetClassFactory(
 inline HRESULT CComClassFactoryProtocol::SetTargetCLSID(REFCLSID clsid,
 	DWORD clsContext)
 {
-	CComPtr<IClassFactory> spTargetCF;
+	ATL::CComPtr<IClassFactory> spTargetCF;
 	HRESULT hr = CoGetClassObject(clsid, clsContext, 0, IID_IClassFactory,
 		reinterpret_cast<void**>(&spTargetCF));
 	ATLASSERT(SUCCEEDED(hr) && spTargetCF != 0);

--- a/ProtocolImpl.h
+++ b/ProtocolImpl.h
@@ -236,16 +236,16 @@ public:
 		/* [out] */		 DWORD *pdwReserved);
 
 public:
-	CComPtr<IUnknown> m_spInternetProtocolUnk;
-	CComPtr<IInternetProtocol> m_spInternetProtocol;
-	CComPtr<IInternetProtocolEx> m_spInternetProtocolEx;
-	CComPtr<IInternetProtocolInfo> m_spInternetProtocolInfo;
-	CComPtr<IInternetPriority> m_spInternetPriority;
-	CComPtr<IInternetThreadSwitch> m_spInternetThreadSwitch;
-	CComPtr<IWinInetInfo> m_spWinInetInfo;
-	CComPtr<IWinInetHttpInfo> m_spWinInetHttpInfo;
-	CComPtr<IWinInetCacheHints> m_spWinInetCacheHints;
-	CComPtr<IWinInetCacheHints2> m_spWinInetCacheHints2;
+	ATL::CComPtr<IUnknown> m_spInternetProtocolUnk;
+	ATL::CComPtr<IInternetProtocol> m_spInternetProtocol;
+	ATL::CComPtr<IInternetProtocolEx> m_spInternetProtocolEx;
+	ATL::CComPtr<IInternetProtocolInfo> m_spInternetProtocolInfo;
+	ATL::CComPtr<IInternetPriority> m_spInternetPriority;
+	ATL::CComPtr<IInternetThreadSwitch> m_spInternetThreadSwitch;
+	ATL::CComPtr<IWinInetInfo> m_spWinInetInfo;
+	ATL::CComPtr<IWinInetHttpInfo> m_spWinInetHttpInfo;
+	ATL::CComPtr<IWinInetCacheHints> m_spWinInetCacheHints;
+	ATL::CComPtr<IWinInetCacheHints2> m_spWinInetCacheHints2;
 };
 
 class ATL_NO_VTABLE IInternetProtocolSinkImpl :
@@ -333,18 +333,18 @@ protected:
 		IInternetProtocol* pTargetProtocol);
 
 public:
-	CComPtr<IInternetProtocolSink> m_spInternetProtocolSink;
-	CComPtr<IServiceProvider> m_spServiceProvider;
-	CComPtr<IInternetBindInfo> m_spInternetBindInfo;
-	CComPtr<IInternetBindInfoEx> m_spInternetBindInfoEx;
-	CComPtr<IUriContainer> m_spUriContainer;
+	ATL::CComPtr<IInternetProtocolSink> m_spInternetProtocolSink;
+	ATL::CComPtr<IServiceProvider> m_spServiceProvider;
+	ATL::CComPtr<IInternetBindInfo> m_spInternetBindInfo;
+	ATL::CComPtr<IInternetBindInfoEx> m_spInternetBindInfoEx;
+	ATL::CComPtr<IUriContainer> m_spUriContainer;
 
-	CComPtr<IInternetProtocol> m_spTargetProtocol;
+	ATL::CComPtr<IInternetProtocol> m_spTargetProtocol;
 };
 
-template <class ThreadModel = CComMultiThreadModel>
+template <class ThreadModel = ATL::CComMultiThreadModel>
 class CInternetProtocolSinkTM :
-	public CComObjectRootEx<ThreadModel>,
+	public ATL::CComObjectRootEx<ThreadModel>,
 	public IInternetProtocolSinkImpl
 {
 private:
@@ -370,7 +370,7 @@ public:
 
 typedef CInternetProtocolSinkTM<> CInternetProtocolSink;
 
-template <class T, class ThreadModel = CComMultiThreadModel>
+template <class T, class ThreadModel = ATL::CComMultiThreadModel>
 class CInternetProtocolSinkWithSP :
 	public CInternetProtocolSinkTM<ThreadModel>
 {
@@ -401,9 +401,9 @@ public:
 			GetUnknown(), riid, ppvObject, GetClientServiceProvider()); \
 	}
 
-template <class StartPolicy, class ThreadModel = CComMultiThreadModel>
+template <class StartPolicy, class ThreadModel = ATL::CComMultiThreadModel>
 class ATL_NO_VTABLE CInternetProtocol :
-	public CComObjectRootEx<ThreadModel>,
+	public ATL::CComObjectRootEx<ThreadModel>,
 	public IInternetProtocolImpl,
 	public StartPolicy
 {

--- a/ProtocolImpl.inl
+++ b/ProtocolImpl.inl
@@ -73,7 +73,7 @@ inline HRESULT WINAPI QueryInterfacePassthrough(void* pv, REFIID riid,
 	HRESULT hr = S_OK;
 	if (!*ppUnk)
 	{
-		CComPtr<IUnknown> spUnk;
+		ATL::CComPtr<IUnknown> spUnk;
 		hr = punkTarget->QueryInterface(riid,
 			reinterpret_cast<void**>(&spUnk));
 		ATLASSERT(FAILED(hr) || spUnk != 0);
@@ -95,7 +95,7 @@ inline HRESULT WINAPI QueryInterfacePassthrough(void* pv, REFIID riid,
 	}
 	if (SUCCEEDED(hr))
 	{
-		CComPtr<IUnknown> spItf = reinterpret_cast<IUnknown*>(
+		ATL::CComPtr<IUnknown> spItf = reinterpret_cast<IUnknown*>(
 			static_cast<char*>(pv) + data.offsetItf);
 		*ppv = spItf.Detach();
 	}
@@ -113,7 +113,7 @@ inline HRESULT WINAPI QueryInterfaceDebug(void* pv, REFIID riid,
 	ATLASSERT(ppv != 0);
 	ATLASSERT(punkTarget != 0);
 
-	CComPtr<IUnknown> spUnk;
+	ATL::CComPtr<IUnknown> spUnk;
 	HRESULT hr = punkTarget->QueryInterface(riid,
 		reinterpret_cast<void**>(&spUnk));
 	ATLASSERT(FAILED(hr) || spUnk != 0);
@@ -134,7 +134,7 @@ inline HRESULT QueryServicePassthrough(REFGUID guidService,
 	IServiceProvider* pClientProvider)
 {
 	ATLASSERT(punkThis != 0);
-	CComPtr<IUnknown> spDummy;
+	ATL::CComPtr<IUnknown> spDummy;
 	HRESULT hr = pClientProvider ?
 		pClientProvider->QueryService(guidService, riid,
 			reinterpret_cast<void**>(&spDummy)) :
@@ -540,7 +540,7 @@ inline HRESULT IInternetProtocolSinkImpl::QueryServiceFromClient(
 	REFGUID guidService, REFIID riid, void** ppvObject)
 {
 	HRESULT hr = S_OK;
-	CComPtr<IServiceProvider> spClientProvider = m_spServiceProvider;
+	ATL::CComPtr<IServiceProvider> spClientProvider = m_spServiceProvider;
 	if (!spClientProvider)
 	{
 		hr = m_spInternetProtocolSink->QueryInterface(&spClientProvider);

--- a/SinkPolicy.h
+++ b/SinkPolicy.h
@@ -55,7 +55,7 @@ private:
 template <class Contained>
 class CComPolyObjectSharedRef :
 	public IUnknown,
-	public CComObjectRootEx<typename Contained::_ThreadModel::ThreadModelNoCS>
+	public ATL::CComObjectRootEx<typename Contained::_ThreadModel::ThreadModelNoCS>
 {
 public:
 	typedef Contained ContainedObject;
@@ -86,7 +86,7 @@ public:
 	Contained* GetContainedObject();
 	static CComPolyObjectSharedRef* GetThisObject(const Contained* pContained);
 
-	CComContainedObject<Contained> m_contained;
+	ATL::CComContainedObject<Contained> m_contained;
 private:
 	IUnknown* m_punkRefCount;
 };
@@ -94,7 +94,7 @@ private:
 template <class T, class ThreadModel>
 class CComObjectRefCount :
 	public IUnknown,
-	public CComObjectRootEx<typename ThreadModel::ThreadModelNoCS>
+	public ATL::CComObjectRootEx<typename ThreadModel::ThreadModelNoCS>
 {
 	STDMETHODIMP QueryInterface(REFIID iid, void** ppvObject);
 	STDMETHODIMP_(ULONG) AddRef();
@@ -146,7 +146,7 @@ public:
 		::PassthroughAPP::CComPolyObjectSharedRef<Protocol>, \
 		::PassthroughAPP::CComObjectSharedRef<Sink> > \
 	ComObjectClass; \
-	typedef CComCreator<ComObjectClass> _CreatorClass;
+	typedef ATL::CComCreator<ComObjectClass> _CreatorClass;
 
 
 template <class Protocol, class Sink>

--- a/SinkPolicy.inl
+++ b/SinkPolicy.inl
@@ -375,8 +375,8 @@ inline HRESULT CustomSinkStartPolicy<Protocol, Sink>::OnStart(LPCWSTR szUrl,
 	HRESULT hr = pSink->OnStart(szUrl, pOIProtSink, pOIBindInfo, grfPI,
 		dwReserved, pTargetProtocol);
 
-	CComPtr<IInternetProtocolSink> spSink;
-	CComPtr<IInternetBindInfo> spBindInfo;
+	ATL::CComPtr<IInternetProtocolSink> spSink;
+	ATL::CComPtr<IInternetBindInfo> spBindInfo;
 	if (SUCCEEDED(hr))
 	{
 		hr = pSink->QueryInterface(IID_IInternetProtocolSink,
@@ -409,8 +409,8 @@ inline HRESULT CustomSinkStartPolicy<Protocol, Sink>::OnStartEx(IUri* pUri,
 	HRESULT hr = pSink->OnStartEx(pUri, pOIProtSink, pOIBindInfo, grfPI,
 		dwReserved, pTargetProtocol);
 
-	CComPtr<IInternetProtocolSink> spSink;
-	CComPtr<IInternetBindInfo> spBindInfo;
+	ATL::CComPtr<IInternetProtocolSink> spSink;
+	ATL::CComPtr<IInternetBindInfo> spBindInfo;
 	if (SUCCEEDED(hr))
 	{
 		hr = pSink->QueryInterface(IID_IInternetProtocolSink,


### PR DESCRIPTION
Explicitly qualify types in namespace ATL.